### PR TITLE
HW5 Assignment

### DIFF
--- a/h2/pom.xml
+++ b/h2/pom.xml
@@ -140,6 +140,18 @@
       <artifactId>asm</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <version>5.7.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- END TEST DEPENDENCIES !-->
   </dependencies>
 

--- a/h2/src/main/org/h2/command/query/Optimizer.java
+++ b/h2/src/main/org/h2/command/query/Optimizer.java
@@ -82,7 +82,9 @@ class Optimizer {
         } else {
             startNs = System.nanoTime();
             if (filters.length <= MAX_BRUTE_FORCE_FILTERS) {
-                calculateBruteForceAll(isSelectCommand);
+                RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(session, filters);
+                TableFilter[] ruleBasedResult = ruleBasedJoinOrderPicker.bestOrder();
+                testPlan(ruleBasedResult, isSelectCommand);
             } else {
                 calculateBruteForceSome(isSelectCommand);
                 random = new Random(0);

--- a/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
+++ b/h2/src/main/org/h2/command/query/RuleBasedJoinOrderPicker.java
@@ -1,0 +1,102 @@
+package org.h2.command.query;
+
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.condition.Comparison;
+import org.h2.expression.condition.ConditionAndOr;
+import org.h2.expression.condition.ConditionAndOrN;
+import org.h2.table.TableFilter;
+
+import java.util.*;
+
+/**
+ * Determines the best join order by following rules rather than considering every possible permutation.
+ */
+public class RuleBasedJoinOrderPicker {
+    final SessionLocal session;
+    final TableFilter[] filters;
+
+    public RuleBasedJoinOrderPicker(SessionLocal session, TableFilter[] filters) {
+        this.session = session;
+        this.filters = filters;
+    }
+
+    public TableFilter[] bestOrder() {
+        Map<TableFilter, List<TableFilter>> joinConnections = buildConnectionGraph();
+
+        Optional<TableFilter> startFilter = Arrays.stream(filters).reduce((filterA, filterB) -> filterA.getTable().getRowCountApproximation(session) < filterB.getTable().getRowCountApproximation(session) ? filterA : filterB);
+
+        List<TableFilter> bestOrderList = new ArrayList<>();
+
+        startFilter.ifPresent(filter -> getOrder(filter, joinConnections, bestOrderList, new HashSet<>()));
+
+        return bestOrderList.toArray(new TableFilter[0]);
+    }
+
+    private Map<TableFilter, List<TableFilter>> buildConnectionGraph() {
+        Map<TableFilter, List<TableFilter>> graph = new HashMap<>();
+
+        for (TableFilter filter : filters) {
+            graph.put(filter, new ArrayList<>());
+        }
+
+        for (TableFilter filter: filters) {
+            Expression fullCondition = filter.getFullCondition();
+            if (fullCondition != null) {
+                addConnections(fullCondition, graph);
+            }
+        }
+
+        return graph;
+    }
+
+    private void addConnections(Expression expression, Map<TableFilter, List<TableFilter>> graph) {
+        if (expression instanceof ConditionAndOr || expression instanceof ConditionAndOrN) {
+            for (int i = 0; i < expression.getSubexpressionCount(); i++) {
+                addConnections(expression.getSubexpression(i), graph);
+            }
+        } else if (expression instanceof Comparison) {
+            System.out.println("Comparison expression");
+            System.out.println(expression);
+
+            Expression left = expression.getSubexpression(0);
+            Expression right = expression.getSubexpression(1);
+
+            if (left instanceof  ExpressionColumn && right instanceof ExpressionColumn) {
+                TableFilter leftFilter = ((ExpressionColumn) left).getTableFilter();
+                TableFilter rightFilter = ((ExpressionColumn) right).getTableFilter();
+
+                System.out.println("Table Filters");
+                System.out.println(leftFilter);
+                System.out.println(rightFilter);
+
+                if (leftFilter != null && rightFilter != null && leftFilter != rightFilter) {
+                    graph.get(leftFilter).add(rightFilter);
+                    graph.get(rightFilter).add(leftFilter);
+                }
+            }
+        }
+    }
+
+    private void getOrder(TableFilter currentFilter, Map<TableFilter, List<TableFilter>> graph, List<TableFilter> order, Set<TableFilter> visited) {
+        visited.add(currentFilter);
+        order.add(currentFilter);
+        System.out.println("Current Order");
+        System.out.println(order);
+
+        List<TableFilter> connections = graph.get(currentFilter);
+
+        if (connections != null) {
+            connections.sort(Comparator.comparingLong(connectedFilter -> connectedFilter.getTable().getRowCountApproximation(session)));
+            System.out.println("Sorted Connections");
+            System.out.println(connections);
+            for (TableFilter connection : connections) {
+                if (!visited.contains(connection)) {
+                    getOrder(connection, graph, order, visited);
+                }
+            }
+        }
+    }
+
+}

--- a/h2/src/main/org/h2/expression/condition/ConditionAndOrN.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionAndOrN.java
@@ -339,4 +339,6 @@ public class ConditionAndOrN extends Condition {
         return expressions.get(index);
     }
 
+
+
 }

--- a/h2/src/main/org/h2/expression/condition/ConditionAndOrN.java
+++ b/h2/src/main/org/h2/expression/condition/ConditionAndOrN.java
@@ -339,6 +339,4 @@ public class ConditionAndOrN extends Condition {
         return expressions.get(index);
     }
 
-
-
 }

--- a/h2/src/main/org/h2/table/TableFilter.java
+++ b/h2/src/main/org/h2/table/TableFilter.java
@@ -1292,4 +1292,7 @@ public class TableFilter implements ColumnResolver {
         }
     }
 
+    public Expression getFullCondition(){
+        return fullCondition;
+    }
 }

--- a/h2/src/test/org/h2/test/command/query/RuleBasedJoinOrderPickerTest.java
+++ b/h2/src/test/org/h2/test/command/query/RuleBasedJoinOrderPickerTest.java
@@ -1,0 +1,245 @@
+package org.h2.test.command.query;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.h2.command.query.RuleBasedJoinOrderPicker;
+import org.h2.engine.Database;
+import org.h2.engine.SessionLocal;
+import org.h2.expression.Expression;
+import org.h2.expression.ExpressionColumn;
+import org.h2.expression.condition.Comparison;
+import org.h2.expression.condition.ConditionAndOr;
+import org.h2.expression.condition.ConditionAndOrN;
+import org.h2.table.Table;
+import org.h2.table.TableFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class RuleBasedJoinOrderPickerTest {
+    SessionLocal mockSession;
+    Database mockDatabase;
+
+    RuleBasedJoinOrderPicker ruleBasedJoinOrderPicker;
+
+    Table customersTable;
+    Table locationsTable;
+    Table ordersTable;
+    Table orderLinesTable;
+
+    ExpressionColumn locationsLocationId;
+
+    ExpressionColumn customersCustomerId;
+    ExpressionColumn customersLocationId;
+
+    ExpressionColumn ordersOrderId;
+    ExpressionColumn ordersLocationId;
+    ExpressionColumn ordersCustomerId;
+
+    ExpressionColumn orderLinesOrderLineId;
+    ExpressionColumn orderLinesOrderId;
+    ExpressionColumn orderLinesLocationId;
+    ExpressionColumn orderLinesCustomerId;
+
+    @BeforeEach
+    public void setUp(){
+        mockSession = Mockito.mock(SessionLocal.class);
+        Mockito.when(mockSession.nextObjectId()).thenReturn(1);
+        mockDatabase = Mockito.mock(Database.class);
+
+        // for the purposes of this unit test, we will use four mock tables with
+        // multiple relationships between them
+        locationsTable = Mockito.mock(Table.class);
+        Mockito.when(locationsTable.getName()).thenReturn("locations");
+        Mockito.when(locationsTable.getRowCountApproximation(mockSession)).thenReturn(15L);
+
+        customersTable = Mockito.mock(Table.class);
+        Mockito.when(customersTable.getName()).thenReturn("customers");
+        Mockito.when(customersTable.getRowCountApproximation(mockSession)).thenReturn(50L);
+
+        ordersTable = Mockito.mock(Table.class);
+        Mockito.when(ordersTable.getName()).thenReturn("orders");
+        Mockito.when(ordersTable.getRowCountApproximation(mockSession)).thenReturn(1000L);
+
+        orderLinesTable = Mockito.mock(Table.class);
+        Mockito.when(orderLinesTable.getName()).thenReturn("orderLines");
+        Mockito.when(orderLinesTable.getRowCountApproximation(mockSession)).thenReturn(5000L);
+
+        // locations (15 rows)
+        //  -> location_id
+        locationsLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(locationsLocationId.getTableName()).thenReturn("locations");
+        // customers (50 rows)
+        //  -> location_id
+        customersCustomerId = Mockito.mock(ExpressionColumn.class);
+        customersLocationId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(customersCustomerId.getTableName()).thenReturn("customers");
+        Mockito.when(customersLocationId.getTableName()).thenReturn("customers");
+        // orders (1,000 rows)
+        //  -> location_id
+        //  -> customer_id
+        ordersOrderId = Mockito.mock(ExpressionColumn.class);
+        ordersLocationId = Mockito.mock(ExpressionColumn.class);
+        ordersCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(ordersOrderId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersLocationId.getTableName()).thenReturn("orders");
+        Mockito.when(ordersCustomerId.getTableName()).thenReturn("orders");
+        // order_lines (5,000)
+        //  -> order_id
+        //  -> location_id
+        //  -> customer_id
+        orderLinesOrderLineId = Mockito.mock(ExpressionColumn.class);
+        orderLinesOrderId = Mockito.mock(ExpressionColumn.class);
+        orderLinesLocationId = Mockito.mock(ExpressionColumn.class);
+        orderLinesCustomerId = Mockito.mock(ExpressionColumn.class);
+        Mockito.when(orderLinesOrderLineId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesOrderId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesLocationId.getTableName()).thenReturn("orderLines");
+        Mockito.when(orderLinesCustomerId.getTableName()).thenReturn("orderLines");
+    }
+
+    @Test
+    public void bestOrder_singleTable(){
+        TableFilter tableFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        tableFilter.setFullCondition(null);
+
+        Mockito.when(customersCustomerId.getTableFilter()).thenReturn(tableFilter);
+        Mockito.when(customersLocationId.getTableFilter()).thenReturn(tableFilter);
+
+        List<TableFilter> expectedFilters = List.of(tableFilter);
+        TableFilter[] inputFilters = {tableFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_twoTablesSingleJoin(){
+        Expression locationsAndCustomers = new Comparison(
+                Comparison.EQUAL,
+                locationsLocationId,
+                customersLocationId,
+                false);
+
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        locationsAndCustomers
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        Mockito.when(locationsLocationId.getTableFilter()).thenReturn(locationsFilter);
+
+        Mockito.when(customersCustomerId.getTableFilter()).thenReturn(customersFilter);
+        Mockito.when(customersLocationId.getTableFilter()).thenReturn(customersFilter);
+
+        // locations is smaller so should go first
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_threeTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        Mockito.when(locationsLocationId.getTableFilter()).thenReturn(locationsFilter);
+
+        Mockito.when(customersCustomerId.getTableFilter()).thenReturn(customersFilter);
+        Mockito.when(customersLocationId.getTableFilter()).thenReturn(customersFilter);
+
+        Mockito.when(ordersOrderId.getTableFilter()).thenReturn(ordersFilter);
+        Mockito.when(ordersLocationId.getTableFilter()).thenReturn(ordersFilter);
+        Mockito.when(ordersCustomerId.getTableFilter()).thenReturn(ordersFilter);
+
+        // size order is locations, customers, orders
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter);
+
+        TableFilter[] inputFilters = {customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+
+    @Test
+    public void bestOrder_fourTablesMultipleJoins(){
+        Expression fullCondition = new ConditionAndOrN(ConditionAndOr.AND,
+                List.of(
+                        new Comparison(Comparison.EQUAL, locationsLocationId, customersLocationId, false),
+                        new Comparison(Comparison.EQUAL, locationsLocationId, ordersLocationId, false),
+                        new Comparison(Comparison.EQUAL, customersCustomerId, ordersCustomerId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesLocationId, locationsLocationId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesOrderId, ordersOrderId, false),
+                        new Comparison(Comparison.EQUAL, orderLinesCustomerId, customersCustomerId, false)
+                )
+        );
+
+        TableFilter locationsFilter = new TableFilter(mockSession, locationsTable, "locations", true, null, 0, null);
+        locationsFilter.setFullCondition(fullCondition);
+
+        TableFilter customersFilter = new TableFilter(mockSession, customersTable, "customers", true, null, 0, null);
+        customersFilter.setFullCondition(fullCondition);
+
+        TableFilter ordersFilter = new TableFilter(mockSession, ordersTable, "orders", true, null, 0, null);
+        ordersFilter.setFullCondition(fullCondition);
+
+        TableFilter orderLinesFilter = new TableFilter(mockSession, orderLinesTable, "orderLines", true, null, 0, null);
+        orderLinesFilter.setFullCondition(fullCondition);
+
+        Mockito.when(locationsLocationId.getTableFilter()).thenReturn(locationsFilter);
+
+        Mockito.when(customersCustomerId.getTableFilter()).thenReturn(customersFilter);
+        Mockito.when(customersLocationId.getTableFilter()).thenReturn(customersFilter);
+
+        Mockito.when(ordersOrderId.getTableFilter()).thenReturn(ordersFilter);
+        Mockito.when(ordersLocationId.getTableFilter()).thenReturn(ordersFilter);
+        Mockito.when(ordersCustomerId.getTableFilter()).thenReturn(ordersFilter);
+
+        Mockito.when(orderLinesOrderLineId.getTableFilter()).thenReturn(orderLinesFilter);
+        Mockito.when(orderLinesOrderId.getTableFilter()).thenReturn(orderLinesFilter);
+        Mockito.when(orderLinesLocationId.getTableFilter()).thenReturn(orderLinesFilter);
+        Mockito.when(orderLinesCustomerId.getTableFilter()).thenReturn(orderLinesFilter);
+
+        // size order is locations, customers, orders, orderLines
+        List<TableFilter> expectedFilters = List.of(locationsFilter, customersFilter, ordersFilter, orderLinesFilter);
+
+        TableFilter[] inputFilters = {orderLinesFilter, customersFilter, ordersFilter, locationsFilter};
+
+        ruleBasedJoinOrderPicker = new RuleBasedJoinOrderPicker(mockSession, inputFilters);
+        List<TableFilter> result = Arrays.asList(ruleBasedJoinOrderPicker.bestOrder());
+
+        assertEquals(expectedFilters, result);
+    }
+}


### PR DESCRIPTION
## Query from HW 4 Problem 4 
 
![image](https://github.com/user-attachments/assets/09830444-173b-4338-b9bf-e7e4d300657e)
 
It chooses the smallest table first then follows a join order that avoids cartesian joins. The query performs much better, selecting users -> followers -> posts.
 
## HW 5 : Query 1 - Single Table
 
![image](https://github.com/user-attachments/assets/044e7407-6dd7-4af4-a519-274570987761)
 
The above explain plan shows that the database is still capable of retrieving data from tables after the code changes.
 
## HW 5 : Query 2 - Just Two Tables
 
![image](https://github.com/user-attachments/assets/c5069dd3-6226-4184-ad4b-e09c6ed1e7f6)
 
The above explain plan shows that the database will start with the table of lower cost when ordering joins.
 
## HW 5 : Query 3 - Three Tables
 
![image](https://github.com/user-attachments/assets/6f6e9c75-da48-4a3a-9792-c17f185f40c9)
 
The above explain plan shows that the database is capable of selecting a join order that avoids cartesian joins.
 
## HW 5 : Query 4 - Four Tables
 
![image](https://github.com/user-attachments/assets/53801e1a-1344-406d-a19b-7aa553ceaeb0)

The above explain plan shows that the database is capable of selecting a join order that avoids cartesian joins even with 4 tables.
 
## HW 5 : Query 5 - Five Tables

![image](https://github.com/user-attachments/assets/3e5aacb0-5f9b-4d11-a350-0aaac0b245cb)
 
The above explain plan shows that the database is capable of selecting a join order that avoids cartesian joins even with 5 tables.
 
## HW 5 : Query 6 - Four Tables, More Options
 
![image](https://github.com/user-attachments/assets/19484dab-8acd-46ad-b7e7-a25d75f8c2f1)

The above explain plan shows that the database is capable of selecting a join order that avoids cartesian joins while also choosing the smallest table.
 
## Our rule based optimizer is still fairly limited.  Can you think of a query in which it would perform a fairly catastrophic join order?
 
A query involving 3 tables where 2 of the tables are only explicitly joined to the smallest/largest table would be catastrophic. There would be no way to start with the smallest table and also join all of the involved tables without a cartesian join.

EXPLAIN ANALYZE
SELECT
    order_payments.order_id,
    orders.order_date,
    order_details.quantity
 
FROM
    order_payments
    JOIN orders ON order_payments.order_id = orders.order_id
    JOIN order_details ON order_payments.order_id = order_details.order_id;
    
![image](https://github.com/user-attachments/assets/d559a34a-7034-4a72-9883-2b02731f0613)

There join order goes from orders to order_details even though there is no explicit join between them.
 
## Our rule based optimizer is still fairly limited.  If you were to improve it, what additional rules would you include?
 
We could also add rules for index selection and avoiding subqueries.